### PR TITLE
Detect TLS handshake failures

### DIFF
--- a/lib/tls_checker/certificate_checker.rb
+++ b/lib/tls_checker/certificate_checker.rb
@@ -47,8 +47,14 @@ module TLSChecker
     end
 
     def certificate
-      @certificate = OpenSSL::X509::Certificate.new(tls_socket.peer_cert) if @certificate.nil?
-      @certificate
+      return @certificate unless @certificate.nil?
+
+      if tls_socket.peer_cert
+        @certificate = OpenSSL::X509::Certificate.new(tls_socket.peer_cert)
+      else
+        @certificate_failure = 'No peer certificate (TLS handshake failed?)'
+        @certificate = false
+      end
     rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ETIMEDOUT, SocketRecvTimeout => e
       @certificate_failure = e.message
       @certificate = false

--- a/spec/tls_checker/certificate_checker_spec.rb
+++ b/spec/tls_checker/certificate_checker_spec.rb
@@ -38,6 +38,12 @@ RSpec.describe TLSChecker::CertificateChecker do
 
     let(:checker) { TLSChecker::CertificateCheckerFactory.new.certificate_checkers_for(specification).first }
 
+    context 'when connecting to an unencrypted service' do
+      let(:specification) { 'opus-labs.fr:80' }
+
+      it { is_expected.to be_falsey }
+    end
+
     context 'when connecting to a TLS service' do
       let(:specification) { 'opus-labs.fr' }
 


### PR DESCRIPTION
This happen when a socket is not connected to a remote TLS service, e.g.
because the service is unencrypted or the TLS connection is forwarder to
an unreachable device.
