### PR TITLE
Fix support for Ruby 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,6 @@ on:
   pull_request:
     branches:
       - main
-  schedule:
-    - cron: "0 17 * * *"
 
 jobs:
   rubocop:
@@ -32,6 +30,8 @@ jobs:
           - "2.7"
           - "3.0"
           - "3.1"
+          - "3.2"
+          - "3.3"
     name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   AllowSymlinksInCacheRootDirectory: true
+  TargetRubyVersion: 2.6
 
 require:
   - rubocop-rake

--- a/lib/tls_checker/certificate_checker.rb
+++ b/lib/tls_checker/certificate_checker.rb
@@ -55,8 +55,8 @@ module TLSChecker
         @certificate_failure = 'No peer certificate (TLS handshake failed?)'
         @certificate = false
       end
-    rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ETIMEDOUT, SocketRecvTimeout => e
-      @certificate_failure = e.message
+    rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ETIMEDOUT, SocketRecvTimeout, IO::TimeoutError => e
+      @certificate_failure = "#{e.class.name}: #{e.message}"
       @certificate = false
     end
 


### PR DESCRIPTION
Ruby 3.2 improved support of timeouts and when a timeout occur, a new
exception previously ignored is raised.

Rescue from such exceptions to preserve previous behavior.

While here, add the actual exception name in the message as it is
sometimes not sufficient, e.g. a Errno::ETIMEDOUT exception used to have
the message "Connection timed out - connect(2) for \"xxx\" port 443",
but a IO::TimeoutError exception have the message "connect(2) for
\"xxx\" port 443" without the root cause.
